### PR TITLE
refreshFix:Removing expiry check

### DIFF
--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -116,7 +116,7 @@ func (p *OIDCProvider) ValidateSession(ctx context.Context, s *sessions.SessionS
 // RefreshSessionIfNeeded checks if the session has expired and uses the
 // RefreshToken to fetch a new Access Token (and optional ID token) if required
 func (p *OIDCProvider) RefreshSessionIfNeeded(ctx context.Context, s *sessions.SessionState) (bool, error) {
-	if s == nil || (s.ExpiresOn != nil && s.ExpiresOn.After(time.Now())) || s.RefreshToken == "" {
+	if s == nil || s.RefreshToken == "" {
 		return false, nil
 	}
 


### PR DESCRIPTION
Current Behaviour :
Oauth proxy refreshes the token only after expire

Expected:
Should refresh the token by the time we set in --cookie-refresh 