### PR TITLE
allow setting arbitrary cookie refresh url

### DIFF
--- a/docs/docs/configuration/alpha_config.md
+++ b/docs/docs/configuration/alpha_config.md
@@ -390,6 +390,7 @@ character.
 | `extraAudiences` | _[]string_ | ExtraAudiences is a list of additional audiences that are allowed<br/>to pass verification in addition to the client id. |
 | `enableCookieRefresh` | _bool_ | Enable cookie refresh functionality that is going to be triggered every time the session is updated |
 | `cookieRefreshName` | _string_ | Name of the cookie that is going to be extracted from the request and refreshed |
+| `cookieRefreshURL` | _string_ | Url that is going to be used to refresh the cookie |
 
 ### Provider
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -395,8 +395,11 @@ func buildSessionChain(opts *options.Options, provider providers.Provider, sessi
 
 	oidcProviderSettings := opts.Providers[0].OIDCConfig
 	if oidcProviderSettings.EnableCookieRefresh {
-		chain = chain.Append(middleware.NewCookieRefresh(&middleware.CookieRefreshOptions{IssuerURL: oidcProviderSettings.IssuerURL, CookieRefreshName: oidcProviderSettings.CookieRefreshName}))
-		logger.Printf("Enabling OIDC cookie refresh for the cookie '%s' functionality because OIDCEnableCookieRefresh is enabled", oidcProviderSettings.CookieRefreshName)
+		if oidcProviderSettings.CookieRefreshURL == "" {
+			oidcProviderSettings.CookieRefreshURL = fmt.Sprintf("%s/session/refresh", oidcProviderSettings.IssuerURL)
+		}
+		chain = chain.Append(middleware.NewCookieRefresh(&middleware.CookieRefreshOptions{CookieRefreshURL: oidcProviderSettings.CookieRefreshURL, CookieRefreshName: oidcProviderSettings.CookieRefreshName}))
+		logger.Printf("Enabling OIDC cookie refresh functionality for the cookie '%s' using the url '%s' because OIDCEnableCookieRefresh is enabled", oidcProviderSettings.CookieRefreshURL, oidcProviderSettings.CookieRefreshName)
 	}
 
 	return chain

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -710,6 +710,7 @@ func (l *LegacyProvider) convert() (Providers, error) {
 		ExtraAudiences:                 l.OIDCExtraAudiences,
 		EnableCookieRefresh:            l.OIDCEnableCookieRefresh,
 		CookieRefreshName:              l.OIDCCookieRefreshName,
+		CookieRefreshURL:               l.OIDCCookieRefreshURL,
 	}
 
 	// Support for legacy configuration option

--- a/pkg/apis/options/legacy_options.go
+++ b/pkg/apis/options/legacy_options.go
@@ -545,6 +545,7 @@ type LegacyProvider struct {
 	OIDCExtraAudiences                 []string `flag:"oidc-extra-audience" cfg:"oidc_extra_audiences"`
 	OIDCEnableCookieRefresh            bool     `flag:"oidc-enable-cookie-refresh" cfg:"oidc_enable_cookie_refresh"`
 	OIDCCookieRefreshName              string   `flag:"oidc-cookie-refresh-name" cfg:"oidc_cookie_refresh_name"`
+	OIDCCookieRefreshURL               string   `flag:"oidc-cookie-refresh-url" cfg:"oidc_cookie_refresh_url"`
 	LoginURL                           string   `flag:"login-url" cfg:"login_url"`
 	RedeemURL                          string   `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL                         string   `flag:"profile-url" cfg:"profile_url"`
@@ -605,6 +606,7 @@ func legacyProviderFlagSet() *pflag.FlagSet {
 	flagSet.StringSlice("oidc-extra-audience", []string{}, "additional audiences allowed to pass audience verification")
 	flagSet.Bool("oidc-enable-cookie-refresh", false, "Refresh the OIDC provider cookies to enable SSO in an extended period of time")
 	flagSet.String("oidc-cookie-refresh-name", "hsdpamcookie", "The name of the cookie that the OIDC provider uses to keep its session fresh")
+	flagSet.String("oidc-cookie-refresh-url", "", "The URL that is going to be used to refresh the cookie")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/pkg/apis/options/providers.go
+++ b/pkg/apis/options/providers.go
@@ -234,6 +234,8 @@ type OIDCOptions struct {
 	EnableCookieRefresh bool `json:"enableCookieRefresh,omitempty"`
 	// Name of the cookie that is going to be extracted from the request and refreshed
 	CookieRefreshName string `json:"cookieRefreshName,omitempty"`
+	// Url that is going to be used to refresh the cookie
+	CookieRefreshURL string `json:"cookieRefreshURL,omitempty"`
 }
 
 type LoginGovOptions struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Allow setting arbitrary URLs for oauth2 proxy cookie refresh mechanism. #49 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
