### PR TITLE
Add audit metric

### DIFF
--- a/pkg/audit/audit_client.go
+++ b/pkg/audit/audit_client.go
@@ -123,11 +123,13 @@ func (c *Client) createAuditEntry(ss *sessions.SessionState, appURL string, tena
 	auditMessage, err := json.Marshal(auditObject)
 	if err != nil {
 		logger.Errorf("%s: could not marshal the audit object: %v", ErrPersitAuditEvent.Error(), err)
+		AuditErrorMetricCounter.Inc()
 		return
 	}
 	err = c.send(string(auditMessage))
 	if err != nil {
 		logger.Errorf("%s: could not send the audit message to the url '%s': %v", ErrPersitAuditEvent.Error(), c.opts.URL, err)
+		AuditErrorMetricCounter.Inc()
 		return
 	}
 }

--- a/pkg/audit/audit_metrics.go
+++ b/pkg/audit/audit_metrics.go
@@ -1,0 +1,11 @@
+package audit
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var AuditErrorMetricCounter = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "oauth2_proxy_audit_errors_requests_total",
+	Help: "Total number of failed audit requests.",
+})


### PR DESCRIPTION
## Description

Adding custom audit metric for audit errors.

## Motivation and Context

This is needed to track audit errors and create alerts when they happen.

## How Has This Been Tested?

Built a local copy from this PR and integrated it with Reporting locally by running the binary. Used invalid audit environment variables to make the audit request fail.

Commands:
- make build
- set envs (grab from Pics containers) and include invalid audit envs
- ./oauth2-proxy --http-address=127.0.0.1:9876 --https-address=127.0.0.1:9877 --metrics-address=127.0.0.1:9090
- change evs in .env.local.worklist-gateway file in pics repo (worklist Oauth) to OAUTH_PROXY_ENDPOINT=host.docker.internal and OAUTH_PROXY_PORT=9876
- run pics

![image](https://github.com/user-attachments/assets/248f2865-4bf3-47dd-83f4-7799931eeb77)