### PR TITLE
Changed the audit event code

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -803,7 +803,7 @@ func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request, si
 		if providerData.BackendLogoutAllSessionsURL == "" {
 			return
 		}
-		p.picsAuditClient.CreateSuccessfulLogoutAuditEntry(session, req.RequestURI, req.Header.Get("edisp-org-id"))
+
 		resp, err := PicsSignOutAllSessions(providerData.BackendLogoutAllSessionsURL, session.IntrospectClaims, session.AccessToken)
 		if err != nil {
 			logger.Errorf("error while calling backend logout all sessions: %v", err)
@@ -813,6 +813,7 @@ func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request, si
 		if resp.StatusCode() != 200 {
 			logger.Errorf("error while calling backend logout url, returned error code %v", resp.StatusCode())
 		}
+		p.picsAuditClient.CreateSuccessfulLogoutAuditEntry(session, req.RequestURI, req.Header.Get("edisp-org-id"))
 	} else {
 		if providerData.BackendLogoutURL == "" {
 			return

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -803,7 +803,7 @@ func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request, si
 		if providerData.BackendLogoutAllSessionsURL == "" {
 			return
 		}
-
+		p.picsAuditClient.CreateSuccessfulLogoutAuditEntry(session, req.RequestURI, req.Header.Get("edisp-org-id"))
 		resp, err := PicsSignOutAllSessions(providerData.BackendLogoutAllSessionsURL, session.IntrospectClaims, session.AccessToken)
 		if err != nil {
 			logger.Errorf("error while calling backend logout all sessions: %v", err)
@@ -813,8 +813,6 @@ func (p *OAuthProxy) backendLogout(rw http.ResponseWriter, req *http.Request, si
 		if resp.StatusCode() != 200 {
 			logger.Errorf("error while calling backend logout url, returned error code %v", resp.StatusCode())
 		}
-
-		p.picsAuditClient.CreateSuccessfulLogoutAuditEntry(session, req.RequestURI, req.Header.Get("edisp-org-id"))
 	} else {
 		if providerData.BackendLogoutURL == "" {
 			return

--- a/pkg/pics/audit/audit_client.go
+++ b/pkg/pics/audit/audit_client.go
@@ -66,7 +66,7 @@ func (c *Client) CreateFailedLoginAuditEntry(ss *sessions.SessionState, appURL s
 
 func (c *Client) CreateSuccessfulLogoutAuditEntry(ss *sessions.SessionState, appURL string, tenantID string) {
 	coding := Coding{
-		System: "http://hl7.org/fhir/ValueSet/audit-event-type", Version: "1", Code: "110123", Display: "Logout", UserSelected: "All Sessions"}
+		System: "http://hl7.org/fhir/ValueSet/audit-event-type", Version: "1", Code: "110114", Display: "Logout", UserSelected: "All Sessions"}
 	c.createAuditEntry(ss, appURL, tenantID, "0", "Success", &coding)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the audit code from 110123 to 110114.

## Motivation and Context

The code 110123 was not present and know by the audit log server.
after running `cf logs oauth_proxy --recent` in the pics_client_test_us_east we saw this error:
`2025-01-14T11:06:04.64+0100 [APP/PROC/WEB/0] ERR 2025/01/14 10:06:04 Not able to send the audit message  {"issue":[{"severity":"error","code":"invalid","details":{"coding":[{"system":"https://www.hl7.org/fhir/valueset-operation-outcome.html","code":"MSG_ERROR_PARSING"}],"text":"Not complaint with AuditEvent specification"},"diagnostics":"Not complaint with AuditEvent specification"}],"resourceType":"OperationOutcome"}`

Unfortunately there is no error message logged in Kibana.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
